### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # 2020-summer-training-template
  
+[![Run on Repl.it](https://repl.it/badge/github/Gryphon-Robotics-4990/2020-summer-training-template)](https://repl.it/github/Gryphon-Robotics-4990/2020-summer-training-template)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment.